### PR TITLE
fixed warnings about naive datetime and deprecated mimetype argument

### DIFF
--- a/myvoice/clinics/models.py
+++ b/myvoice/clinics/models.py
@@ -1,4 +1,5 @@
 import datetime
+from pytz import UTC
 
 from django.contrib.gis.db import models as gis
 from django.core.exceptions import ValidationError
@@ -6,6 +7,10 @@ from django.db import models
 
 from myvoice.core.validators import validate_year
 from myvoice.statistics.models import Statistic
+
+
+def get_current_datetime():
+    return datetime.datetime.now().replace(tzinfo=UTC)
 
 
 class Region(gis.Model):
@@ -150,7 +155,7 @@ class Visit(models.Model):
     patient = models.ForeignKey('Patient')
     service = models.ForeignKey('Service', blank=True, null=True)
     staff = models.ForeignKey('ClinicStaff', blank=True, null=True)
-    visit_time = models.DateTimeField(default=datetime.datetime.now)
+    visit_time = models.DateTimeField(default=get_current_datetime)
     survey_sent = models.BooleanField(default=False)
 
     def __unicode__(self):

--- a/myvoice/clinics/views.py
+++ b/myvoice/clinics/views.py
@@ -70,7 +70,7 @@ class VisitView(View):
         else:
             data = json.dumps({'text': self.get_error_msg(form)})
 
-        response = HttpResponse(data, mimetype='text/json')
+        response = HttpResponse(data, content_type='text/json')
 
         # This is to test webhooks from localhost
         # response['Access-Control-Allow-Origin'] = '*'

--- a/myvoice/core/tests/factories.py
+++ b/myvoice/core/tests/factories.py
@@ -5,6 +5,7 @@ import string
 import factory
 import factory.django
 import factory.fuzzy
+from pytz import UTC
 
 from django.contrib.auth import models as auth
 
@@ -71,6 +72,7 @@ class Visit(factory.django.DjangoModelFactory):
 
     patient = factory.SubFactory('myvoice.core.tests.factories.Patient')
     service = factory.SubFactory('myvoice.core.tests.factories.Service')
+    visit_time = factory.fuzzy.FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC))
 
 
 class GenericFeedback(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Removed default value of datetime.datetime in clinics.Visit.visit_time field and made the default a function
Replaced mimetype argument with content_type in HttpResponse object
